### PR TITLE
Adding String Validator Builder

### DIFF
--- a/builder.js
+++ b/builder.js
@@ -1,0 +1,49 @@
+/**
+ * String validator builder class
+ * Allow to build a template for string validations
+ *
+ * Author: Theekshana Wijesinghe
+ */
+
+const StringValidator = require('./');
+
+// These are the public methods exposed by StringValidator class
+const stringValidatorExposedMethod = ['length', 'max', 'min', 'regex', 'includes', 'allow'];
+
+/**
+ * Functional wrapper that expose String validator methods
+ * This allow to builder for string validations
+ */
+const stringValidatorWrapper = () => {
+
+    // Will expose all methods allowed by the class
+    const exposed = {};
+    // Track methods call and the param passed key: method and value: param
+    const methodTracker = {};
+
+    // Expose all the methods
+    // When a method is called save the params
+    // Return exposed object to allow chaining
+    stringValidatorExposedMethod.forEach((method) => {
+       exposed[method] = (param) => {
+           methodTracker[method] = param;
+           return exposed;
+       };
+    });
+
+    // Return a function that will validate at function call
+    exposed.build = () => {
+        return (value) => {
+            let validator = new StringValidator(value);
+            // Iterate over the methods called and validate
+            for(const [method, param] of Object.entries(methodTracker)) {
+               validator = validator[method](param);
+            }
+            return validator.validate(); // validate the value
+        }
+    };
+    return exposed;
+};
+
+module.exports = stringValidatorWrapper;
+

--- a/builder.js
+++ b/builder.js
@@ -1,5 +1,5 @@
 /**
- * String validator builder class
+ * String validator builder function
  * Allow to build a template for string validations
  *
  * Author: Theekshana Wijesinghe
@@ -8,7 +8,7 @@
 const StringValidator = require('./');
 
 // These are the public methods exposed by StringValidator class
-const stringValidatorExposedMethod = ['length', 'max', 'min', 'regex', 'includes', 'allow'];
+const stringValidatorExposedMethods = ['length', 'max', 'min', 'regex', 'includes', 'allow'];
 
 /**
  * Functional wrapper that expose String validator methods
@@ -24,7 +24,7 @@ const stringValidatorWrapper = () => {
     // Expose all the methods
     // When a method is called save the params
     // Return exposed object to allow chaining
-    stringValidatorExposedMethod.forEach((method) => {
+    stringValidatorExposedMethods.forEach((method) => {
        exposed[method] = (param) => {
            methodTracker[method] = param;
            return exposed;

--- a/builder.js
+++ b/builder.js
@@ -7,8 +7,21 @@
 
 const StringValidator = require('./');
 
-// These are the public methods exposed by StringValidator class
-const stringValidatorExposedMethods = ['length', 'max', 'min', 'regex', 'includes', 'allow'];
+
+// Capture all the public methods exposed by StringValidator class
+const stringValidatorExposedMethods = [];
+
+// These methods of StringValidator will not be exposed
+const stringValidatorBlackListedMethod = ['constructor'];
+
+// IIFY: Get exposed methods by excluding black listed methods
+(() => {
+    Object.getOwnPropertyNames(StringValidator.prototype).forEach((method) => {
+        if (!stringValidatorBlackListedMethod.includes(method)) {
+            stringValidatorExposedMethods.push(method);
+        }
+    })
+})();
 
 /**
  * Functional wrapper that expose String validator methods

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "js-string-validator",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "JS String validator utility class",
   "main": "index.js",
   "scripts": {
-    "test": "node string-validator-tests.js"
+    "test": "node string-validator-tests.js && node string-validator-builder-tests.js"
   },
   "repository": {
     "type": "git",

--- a/string-validator-builder-tests.js
+++ b/string-validator-builder-tests.js
@@ -1,0 +1,40 @@
+const assert = require('assert').strict;
+
+const StringValidateBuilder = require('./builder');
+
+
+// builder basic tests -------------------------------------------------------------
+
+const validator = StringValidateBuilder()
+						.length(3)
+						.min(2)
+						.max(5)
+						.regex(/\d+/)
+						.includes(2)
+						.build();
+
+assert(validator('123'), 'should assert true since "123: satisfies the conditions in the builder');
+assert(!validator(), 'should assert false since undefined does not satisfy the builder');
+assert(!validator("abc"), 'should assert false since "abc" does not satisfy builder');
+
+
+const anotherValidator = StringValidateBuilder()
+							.length(3)
+							.allow(undefined)
+							.min(2)
+							.build();
+
+
+assert(anotherValidator(), 'should assert true since undefined is allowed');
+assert(anotherValidator("abc"), 'should assert true since abc is a valid');
+
+
+const someOtherValidator = StringValidateBuilder()
+								.max(0)
+								.build();
+
+
+assert(!someOtherValidator('b'), 'should assert false since given string has a length');
+
+
+console.log('Successfully passed all String Validator Builder tests');

--- a/string-validator-tests.js
+++ b/string-validator-tests.js
@@ -55,7 +55,7 @@ const anotherInvalidCase = validator
 
 assert(!anotherInvalidCase, 'should assert false since given string has a length');
 
-// builder test ---------------------------------------------------------------------------------------
+// String Validator method test ---------------------------------------------------------------------------------------
 
 let stringValidator;
 let err;
@@ -167,4 +167,4 @@ stringValidator = new StringValidator(null);
 isValid = stringValidator.max(10).allow(null).validate();
 assert(isValid, 'should validate true if null is allowed given constructor invoked with null');
 
-console.log('Successfully passed all tests');
+console.log('Successfully passed all String Validator tests');


### PR DESCRIPTION
Adding a new String Validator Builder.
This will allow creating a template to validate various strings without the need for `new`

## How to use 
```
const StringValidatorBuilder = require('js-string-validator/builder');
  
const validator = StringValidatorBuilder().min(0).max(20).regex(/\s+/).includes('string').build();

console.log(validator('some string'));
// true  -> comply the pattern

console.log(validator('random'));
// false -> violates the pattern

console.log(validator());
// false -> undefined not allowed
```
 